### PR TITLE
fix: content hydration problem

### DIFF
--- a/resources/js/filament-tiptap-editor.js
+++ b/resources/js/filament-tiptap-editor.js
@@ -167,6 +167,12 @@ document.addEventListener("alpine:init", () => {
             e.target.firstChild.style.pointerEvents = "all";
           }
         });
+
+        this.$watch('state', (newState) => {
+          if (editors[this.id].getHTML() !== newState){
+            editors[this.id].commands.setContent(newState)
+          }
+        })
       },
       editor() {
         return editors[this.id];


### PR DESCRIPTION
This pr contains below problem fix;

when use with `spatie-translatable` plugin, editor content don't update when change locale