### PR TITLE
Fix: drop enums until Filament v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ TiptapEditor::make('content')
     ->directory('string or Closure returning a string') // optional, defaults to config setting
     ->acceptedFileTypes(['array of file types']) // optional, defaults to config setting
     ->maxFileSize('integer in KB') // optional, defaults to config setting
-    ->output(TiptapOutput::Json) // optional, change the output format. defaults is html
+    ->output('json') // optional, change the output format. defaults is html
     ->required();
 ```
 
@@ -77,23 +77,9 @@ Tools can also be added on a per instance basis. Using the `->tools()` modifier 
 Tiptap editor has 3 different output formats.
 See: https://tiptap.dev/guide/output
 
-
 If you want to change the output format you can change the default config or specify it in each form instances.
 For each form field instances you can add the following option:
 
-**For php 8.1**
-```php
-    TiptapEditor::make('content')
-        // ... other options
-        ->output(FilamentTiptapEditor\Enums\TiptapOutput::Json);
-```
-
-- HTML (Format enum type: `FilamentTiptapEditor\Enums\TiptapOutput::Html`)
-- JSON (Format enum type: `FilamentTiptapEditor\Enums\TiptapOutput::Json`)
-- Text (Format enum type: `FilamentTiptapEditor\Enums\TiptapOutput::Text`)
-
-
-**For php 8.0**
 ```php
     TiptapEditor::make('content')
         // ... other options
@@ -103,7 +89,6 @@ For each form field instances you can add the following option:
 - HTML (Format type: `FilamentTiptapEditor\TiptapEditor::OUTPUT_HTML`)
 - JSON (Format type: `FilamentTiptapEditor\TiptapEditor::OUTPUT_JSON`)
 - Text (Format type: `FilamentTiptapEditor\TiptapEditor::OUTPUT_TEXT`)
-
 
 **or as string**
 ```php
@@ -115,7 +100,6 @@ For each form field instances you can add the following option:
 - HTML (`html`)
 - JSON (`json`)
 - Text (`text`)
-
 
 **Note:**
 

--- a/config/filament-tiptap-editor.php
+++ b/config/filament-tiptap-editor.php
@@ -81,8 +81,7 @@ return [
     |
     | Which output format should be the default.
     | Available formats:
-    | > For php 8.0: TiptapEditor::OUTPUT_HTML | TiptapEditor::OUTPUT_JSON | TiptapEditor::OUTPUT_TEXT
-    | > For php 8.1: TiptapOutput::Html | TiptapOutput::Json | TiptapOutput::Text
+    | > TiptapEditor::OUTPUT_HTML | TiptapEditor::OUTPUT_JSON | TiptapEditor::OUTPUT_TEXT
     | > or only as string: 'html', 'json', 'text'
     |
     | See: https://tiptap.dev/guide/output

--- a/resources/js/plugin.js
+++ b/resources/js/plugin.js
@@ -169,7 +169,7 @@ document.addEventListener("alpine:init", () => {
                 }
             });
 
-            let sortableEl = this.$el.parentElement.closest("[wire\\:sortable");
+            let sortableEl = this.$el.parentElement.closest("[wire\\:sortable]");
             if (sortableEl) {
                 window.Sortable.utils.on(sortableEl, "start", (event) => {
                     Object.values(editors).forEach(function (editor) {

--- a/src/TiptapEditor.php
+++ b/src/TiptapEditor.php
@@ -8,7 +8,6 @@ use Filament\Support\Concerns\HasExtraAlpineAttributes;
 use Filament\Forms\Components\Concerns\CanBeLengthConstrained;
 use Filament\Forms\Components\Concerns\HasExtraInputAttributes;
 use Filament\Forms\Components\Contracts\CanBeLengthConstrained as CanBeLengthConstrainedContract;
-use FilamentTiptapEditor\Enums\TiptapOutput;
 use FilamentTiptapEditor\Exceptions\InvalidOutputFormatException;
 
 class TiptapEditor extends Field implements CanBeLengthConstrainedContract
@@ -37,7 +36,7 @@ class TiptapEditor extends Field implements CanBeLengthConstrainedContract
 
     protected ?int $maxFileSize = 2042;
 
-    protected null | string | TiptapOutput $output = null;
+    protected null | string $output = null;
 
     protected function setUp(): void
     {
@@ -48,7 +47,7 @@ class TiptapEditor extends Field implements CanBeLengthConstrainedContract
         $this->validateOutputFormat();
 
         $this->beforeStateDehydrated(function(TiptapEditor $component, string $state) {
-            if ($this->output === TiptapOutput::Json || $this->output === self::OUTPUT_JSON) {
+            if ($this->output === self::OUTPUT_JSON) {
                 $component->state(json_decode($state));
             }
         });
@@ -96,7 +95,7 @@ class TiptapEditor extends Field implements CanBeLengthConstrainedContract
         return $this;
     }
 
-    public function output(TiptapOutput | string $output): static
+    public function output(string $output): static
     {
         $this->output = $output;
         $this->validateOutputFormat();
@@ -131,9 +130,7 @@ class TiptapEditor extends Field implements CanBeLengthConstrainedContract
 
     public function getOutput(): string
     {
-        return ($this->output instanceof TiptapOutput)
-            ? $this->output->value
-            : $this->output;
+        return $this->output;
     }
 
     protected function validateOutputFormat(): void 
@@ -143,10 +140,6 @@ class TiptapEditor extends Field implements CanBeLengthConstrainedContract
             self::OUTPUT_JSON,
             self::OUTPUT_TEXT,
         ];
-
-        if ($this->output instanceof TiptapOutput) {
-            return;
-        }
 
         if (!in_array($this->output, $availableFormats)) {
             throw new InvalidOutputFormatException;


### PR DESCRIPTION
Removes enums until support for php 8.0 is dropped from Filament.