### PR TITLE
Fix: maxFileSize method default value bug

### DIFF
--- a/src/TiptapEditor.php
+++ b/src/TiptapEditor.php
@@ -39,7 +39,7 @@ class TiptapEditor extends Field implements CanBeLengthConstrainedContract
 
     protected ?array $acceptedFileTypes = null;
 
-    protected ?int $maxFileSize = 2042;
+    protected ?int $maxFileSize = null;
 
     protected null | string $output = null;
 
@@ -185,7 +185,7 @@ class TiptapEditor extends Field implements CanBeLengthConstrainedContract
         return $this;
     }
 
-    public function maxFileSize(?int $maxFileSize): static
+    public function maxFileSize(int $maxFileSize): static
     {
         $this->maxFileSize = $maxFileSize;
 


### PR DESCRIPTION
Fixes bug created by not having $maxFileSize defaulted to null so it can fall back to config setting.