### PR TITLE
fix: vite facade not callable

### DIFF
--- a/src/FilamentTiptapEditorServiceProvider.php
+++ b/src/FilamentTiptapEditorServiceProvider.php
@@ -66,7 +66,7 @@ class FilamentTiptapEditorServiceProvider extends PluginServiceProvider
             $builder = config('filament-tiptap-editor.theme_builder');
 
             if ($builder == 'vite') {
-                $theme = app(Vite::class)($themeFile, config('filament-tiptap-editor.theme_folder'));
+                $theme = Vite::asset($themeFile, config('filament-tiptap-editor.theme_folder'));
             } else {
                 $theme = mix($themeFile);
             }


### PR DESCRIPTION
fixes issue where when using Vite for custom css 
`Object of type Illuminate\Support\Facades\Vite is not callable`