### PR TITLE
Fix text and background colors in dark mode

### DIFF
--- a/resources/views/components/dropdown-button.blade.php
+++ b/resources/views/components/dropdown-button.blade.php
@@ -37,7 +37,7 @@
         }"
         x-cloak
         @class([
-            'absolute z-30 bg-gray-800 rounded-md shadow-md top-full',
+            'absolute z-30 bg-gray-300 dark:bg-gray-800 rounded-md shadow-md top-full',
             'overflow-y-scroll max-h-48' => ! $active,
         ])
     >

--- a/resources/views/components/dropdown-button.blade.php
+++ b/resources/views/components/dropdown-button.blade.php
@@ -43,7 +43,7 @@
     >
         <div x-ref="arrow" class="absolute z-0 bg-inherit w-2 h-2 transform rotate-45"></div>
         @if ($list)
-            <ul class="text-sm divide-y divide-gray-700 min-w-[144px]">
+            <ul class="text-sm divide-y divide-gray-300 dark:divide-gray-700 min-w-[144px]">
                 {{ $slot }}
             </ul>
         @else

--- a/resources/views/components/dropdown-button.blade.php
+++ b/resources/views/components/dropdown-button.blade.php
@@ -37,7 +37,7 @@
         }"
         x-cloak
         @class([
-            'absolute z-30 bg-gray-300 dark:bg-gray-800 rounded-md shadow-md top-full',
+            'absolute z-30 bg-gray-100 dark:bg-gray-800 rounded-md shadow-md top-full',
             'overflow-y-scroll max-h-48' => ! $active,
         ])
     >

--- a/resources/views/tiptap-editor.blade.php
+++ b/resources/views/tiptap-editor.blade.php
@@ -19,7 +19,7 @@
     :state-path="$statePath"
 >
     <div @class([
-        'tiptap-editor border rounded-md relative bg-white shadow-sm dark:bg-gray-700',
+        'tiptap-editor border rounded-md relative bg-white shadow-sm dark:bg-gray-700 text-gray-600 dark:text-gray-200',
         'border-gray-200 dark:border-gray-600' => ! $errors->has($statePath),
         'border-danger-600 ring-danger-600' => $errors->has($statePath),
     ])>


### PR DESCRIPTION
When using the plugin with a standalone forms builder, there are some issues with the text and background colors between dark and light

Before in the dark:
<img width="1088" alt="Screenshot 2023-06-28 at 2 36 49 AM" src="https://github.com/awcodes/filament-tiptap-editor/assets/1952412/65b5fbb1-fbc6-4ec1-865c-c421a3bc3d22">

After in the dark:
<img width="1095" alt="Screenshot 2023-06-28 at 2 36 22 AM" src="https://github.com/awcodes/filament-tiptap-editor/assets/1952412/f068ee62-3ad1-4329-9ae2-25f79d7ca196">


Before in th
<img width="1093" alt="Screenshot 2023-06-28 at 2 42 23 AM" src="https://github.com/awcodes/filament-tiptap-editor/assets/1952412/57b3006f-0571-43fe-ad87-f4f9e49c2563">
e light:

After in the light:
<img width="1095" alt="Screenshot 2023-06-28 at 2 41 43 AM" src="https://github.com/awcodes/filament-tiptap-editor/assets/1952412/0a7185a1-3214-42a6-aee7-ecce167e1b12">



