### PR TITLE
Added 'none' profile for editor without any tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ use FilamentTiptapEditor\TiptapEditor;
 use FilamentTiptapEditor\Enums\TiptapOutput;
 
 TiptapEditor::make('content')
-    ->profile('default|simple|minimal|custom')
+    ->profile('default|simple|minimal|none|custom')
     ->tools([]) // individual tools to use in the editor, overwrites profile
     ->disk('string') // optional, defaults to config setting
     ->directory('string or Closure returning a string') // optional, defaults to config setting

--- a/config/filament-tiptap-editor.php
+++ b/config/filament-tiptap-editor.php
@@ -37,6 +37,7 @@ return [
         ],
         'simple' => ['heading', 'hr', 'bullet-list', 'ordered-list', 'checked-list', '|', 'bold', 'italic', 'lead', 'small', '|', 'link', 'media'],
         'minimal' => ['bold', 'italic', 'link', 'bullet-list', 'ordered-list'],
+        'none' => []
     ],
 
     /*

--- a/resources/views/tiptap-editor.blade.php
+++ b/resources/views/tiptap-editor.blade.php
@@ -42,7 +42,7 @@
             x-trap.noscroll="fullScreenMode"
         >
 
-            @if (! $isDisabled)
+            @if (! $isDisabled && $tools)
                 <button type="button" x-on:click="editor().chain().focus()" class="z-20 rounded sr-only focus:not-sr-only focus:absolute focus:py-1 focus:px-3 focus:bg-white focus:text-gray-900">{{ __('filament-tiptap-editor::editor.skip_toolbar') }}</button>
 
                 <div class="tiptap-toolbar text-gray-800 border-b border-gray-950/10 bg-gray-50 divide-x divide-gray-950/10 rounded-t-md z-[1] relative flex flex-col md:flex-row dark:text-gray-300 dark:border-white/20 dark:bg-gray-950 dark:divide-white/20">

--- a/src/TiptapEditor.php
+++ b/src/TiptapEditor.php
@@ -253,7 +253,12 @@ class TiptapEditor extends Field implements FilamentCanBeLengthConstrained
 
     public function getFloatingMenuTools(): array
     {
-        return $this->evaluate($this->floatingMenuTools) ?? config('filament-tiptap-editor.floating_menu_tools');
+        if ($this->floatingMenuTools) {
+            return $this->evaluate($this->floatingMenuTools);
+        } elseif ($this->profile !== 'none') {
+            return config('filament-tiptap-editor.floating_menu_tools');
+        }
+        return [];
     }
 
     public function getMaxContentWidth(): string


### PR DESCRIPTION
Allow for simple text paragraphs editor only without any controls.

```php
TiptapEditor::make('content')
    ->profile('none')
```
<img width="809" alt="Screenshot 2023-08-10 at 13 33 10" src="https://github.com/awcodes/filament-tiptap-editor/assets/533658/10b4181c-8edf-4905-a01a-eb9150f8cfa8">
