### PR TITLE
WIP: Add Color mark

### DIFF
--- a/src/Extensions/Marks/Color.php
+++ b/src/Extensions/Marks/Color.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace FilamentTiptapEditor\Extensions\Marks;
+
+use Tiptap\Core\Mark;
+use Tiptap\Utils\HTML;
+
+class Color extends Mark
+{
+    public static $name = 'color';
+
+    public function addOptions(): array
+    {
+        return [
+            'HTMLAttributes' => [],
+        ];
+    }
+
+    public function parseHTML(): array
+    {
+        return [
+            [
+                'style' => 'color',
+            ],
+        ];
+    }
+
+    public function renderHTML($mark, $HTMLAttributes = []): array
+    {
+        return [
+            'span',
+            HTML::mergeAttributes($this->options['HTMLAttributes'], $HTMLAttributes),
+            0,
+        ];
+    }
+}

--- a/src/TiptapConverter.php
+++ b/src/TiptapConverter.php
@@ -63,6 +63,7 @@ class TiptapConverter
             new Subscript(),
             new Marks\Link(),
             new Marks\Small(),
+            new Marks\Color(),
         ];
     }
 


### PR DESCRIPTION
When you pick a color via the colorpicker and save it. After reloading the page the whole span tag is removed.
It's saved correctly, I have this value in my database `<p>Test a <span style="color: #00FFF0">color</span></p>`

But when Tiptap is rendered again or `{!! tiptap_converter()->asHTML($post->content) !!}` is used, the value of the tiptap editor becomes `<p>Test a color</p>`.

This can be reproduced in the [Peek demo](https://github.com/pboivin/filament-peek-demo).

I already figured it out with a missing Tiptap PHP extension (https://github.com/ueberdosis/tiptap-php/pull/24), so I wonder if it can be added here. 

I already gave it a try, but can't get it to work, the HTMLAttributes in renderHTML are always empty. Also the extension in the pull request above doesn't seem to work (anymore).

With this code I already managed to get back `<p>Test a <span>color</span></p>`, but I have no clue how to get the color value in the `renderHTML` method.