### PR TITLE
Use svg syntax for icons

### DIFF
--- a/resources/views/tiptap-editor.blade.php
+++ b/resources/views/tiptap-editor.blade.php
@@ -153,11 +153,11 @@
                                     <p class="text-xs font-bold" x-show="! isCollapsed">Blocks</p>
 
                                     <button x-on:click="isCollapsed = false" x-show="isCollapsed" x-cloak type="button" class="ml-auto">
-                                        <x-heroicon-m-bars-3 class="w-5 h-5" />
+                                        @svg('heroicon-m-bars-3', 'w-5 h-5')
                                     </button>
 
                                     <button x-on:click="isCollapsed = true" x-show="! isCollapsed" type="button" class="ml-auto">
-                                        <x-heroicon-m-x-mark class="w-5 h-5" />
+                                        @svg('heroicon-m-x-mark', 'w-5 h-5')
                                     </button>
                                 </div>
 


### PR DESCRIPTION
[Since 3.x Filament uses the `@svg` syntax by default.](https://filamentphp.com/docs/3.x/panels/upgrade-guide#blade-icon-components-have-been-disabled)

Disabling components inside the `blade-icons.php` config file, results in the following error anywhere `TiptapEditor` is used:

<img width="1382" alt="image" src="https://github.com/awcodes/filament-tiptap-editor/assets/87341175/072d0a73-897c-4f77-be5c-9d185a253783">

This PR replaces the usage of components with the `@svg` syntax to resolve the above error.