### PR TITLE
feat: Disable toolbar menus

### DIFF
--- a/config/filament-tiptap-editor.php
+++ b/config/filament-tiptap-editor.php
@@ -79,5 +79,7 @@ return [
     */
     'disable_floating_menus' => false,
     'disable_bubble_menus' => false,
+    'disable_toolbar_menus' => false,
+    
     'floating_menu_tools' => ['media', 'grid-builder', 'details', 'table', 'oembed', 'code-block', 'blocks'],
 ];

--- a/resources/views/tiptap-editor.blade.php
+++ b/resources/views/tiptap-editor.blade.php
@@ -67,7 +67,7 @@
                     x-on:delete-block.window="deleteBlock()"
                     x-trap.noscroll="fullScreenMode"
                 >
-                    @if (! $isDisabled && $tools)
+                    @if (! $isDisabled && ! $isToolbarMenusDisabled() && $tools)
                         <button type="button" x-on:click="editor().chain().focus()" class="z-20 rounded sr-only focus:not-sr-only focus:absolute focus:py-1 focus:px-3 focus:bg-white focus:text-gray-900">{{ __('filament-tiptap-editor::editor.skip_toolbar') }}</button>
 
                         <div class="tiptap-toolbar text-gray-800 border-b border-gray-950/10 bg-gray-50 divide-x divide-gray-950/10 rounded-t-md z-[1] relative flex flex-col md:flex-row dark:text-gray-300 dark:border-white/20 dark:bg-gray-950 dark:divide-white/20">

--- a/src/Concerns/InteractsWithMenus.php
+++ b/src/Concerns/InteractsWithMenus.php
@@ -9,8 +9,10 @@ trait InteractsWithMenus
     protected array | Closure | null $floatingMenuTools = null;
 
     protected ?bool $shouldShowBubbleMenus = null;
-
+    
     protected ?bool $shouldShowFloatingMenus = null;
+    
+    protected ?bool $shouldShowToolbarMenus = null;
 
     public function disableBubbleMenus(bool | Closure | null $condition = true): static
     {
@@ -22,6 +24,13 @@ trait InteractsWithMenus
     public function disableFloatingMenus(bool | Closure | null $condition = true): static
     {
         $this->shouldShowFloatingMenus = $condition;
+
+        return $this;
+    }
+
+    public function disableToolbarMenus (bool | Closure | null $condition = true): static
+    {
+        $this->shouldShowToolbarMenus = $condition;
 
         return $this;
     }
@@ -53,4 +62,9 @@ trait InteractsWithMenus
     {
         return $this->evaluate($this->shouldShowBubbleMenus) ?? config('filament-tiptap-editor.disable_bubble_menus');
     }
+
+    public function isToolbarMenusDisabled(): bool
+    {
+        return $this->evaluate($this->shouldShowToolbarMenus) ?? config('filament-tiptap-editor.disable_toolbar_menus');
+    }    
 }


### PR DESCRIPTION
Allows to hide the toolbar for an even more minimalistic look.

![image](https://github.com/awcodes/filament-tiptap-editor/assets/3843774/ca724ef3-6bea-47ed-8081-fd172b0b48db)
