### PR TITLE
fix: custom block uses width as label

### DIFF
--- a/src/TiptapEditor.php
+++ b/src/TiptapEditor.php
@@ -245,7 +245,7 @@ class TiptapEditor extends Field
                         return null;
                     }
 
-                    return $block->getModalWidth();
+                    return trans('filament-tiptap-editor::editor.blocks.insert');
                 }
 
                 return trans('filament-tiptap-editor::editor.blocks.insert');


### PR DESCRIPTION
Related to issue #272 