### PR TITLE
Check if color isset on attribute object before accessing it

### DIFF
--- a/src/Extensions/Extensions/Color.php
+++ b/src/Extensions/Extensions/Color.php
@@ -28,7 +28,7 @@ class Color extends Extension
                             return InlineStyle::getAttribute($DOMNode, 'color') ?? false;
                         },
                         'renderHTML' => function ($attributes) {
-                            if (! $attributes->color) {
+                            if (! isset($attributes->color) || ! $attributes->color) {
                                 return null;
                             }
 


### PR DESCRIPTION
Fixes also https://github.com/awcodes/filament-tiptap-editor/issues/286 I think.

But we had an issue where copying from Figma or Word added a `<span>` without attributes around some of the text and this check gave a 500. So adding the `isset()` check before accessing it fixes the server error.