### PR TITLE
Inject current Filament component in each preview blade file

### DIFF
--- a/src/TiptapBlock.php
+++ b/src/TiptapBlock.php
@@ -52,7 +52,7 @@ abstract class TiptapBlock
         return [];
     }
 
-    public function getPreview(array | null $data = [], ?Component $component): string
+    public function getPreview(array | null $data = [], Component | null $component = null): string
     {
         return view($this->preview, [
             ...$data,

--- a/src/TiptapBlock.php
+++ b/src/TiptapBlock.php
@@ -3,6 +3,7 @@
 namespace FilamentTiptapEditor;
 
 use Filament\Support\Concerns\EvaluatesClosures;
+use Filament\Forms\Components\Component;
 use Illuminate\Support\Str;
 
 abstract class TiptapBlock
@@ -51,9 +52,12 @@ abstract class TiptapBlock
         return [];
     }
 
-    public function getPreview(array | null $data = []): string
+    public function getPreview(array | null $data = [], ?Component $component): string
     {
-        return view($this->preview, $data)->render();
+        return view($this->preview, [
+            ...$data,
+            'component' => $component
+        ])->render();
     }
 
     public function getRendered(array | null $data = []): string

--- a/src/TiptapEditor.php
+++ b/src/TiptapEditor.php
@@ -332,7 +332,7 @@ class TiptapEditor extends Field
                     statePath: $component->getStatePath(),
                     type: $arguments['type'],
                     data: Js::from($data)->toHtml(),
-                    preview: $block->getPreview($data),
+                    preview: $block->getPreview($data, $component),
                     label: $block->getLabel(),
                 );
             });

--- a/src/TiptapEditor.php
+++ b/src/TiptapEditor.php
@@ -293,7 +293,7 @@ class TiptapEditor extends Field
                     statePath: $component->getStatePath(),
                     type: $arguments['type'],
                     data: Js::from($data)->toHtml(),
-                    preview: $block->getPreview($data),
+                    preview: $block->getPreview($data, $component),
                     label: $block->getLabel(),
                     coordinates: $arguments['coordinates'] ?? [],
                 );

--- a/src/TiptapEditor.php
+++ b/src/TiptapEditor.php
@@ -182,7 +182,7 @@ class TiptapEditor extends Field
             if ($block['type'] === 'tiptapBlock') {
                 $instance = $this->getBlock($block['attrs']['type']);
                 $orderedAttrs = [
-                    'preview' => $instance->getPreview($block['attrs']['data']),
+                    'preview' => $instance->getPreview($block['attrs']['data'], $component),
                     'statePath' => $component->getStatePath(),
                     'type' => $block['attrs']['type'],
                     'label' => $instance->getLabel(),


### PR DESCRIPTION
This pull request adds an additional param to the `getPreview` method to inject the current component (TiptapEditor) to each preview Blade file.

This enables the user to have access ie. to the current record when editing in the panel. 

Example blade file:
```php
@if ($image)
    <img src="/{{ $image }}" alt="{{ $caption }}"/>
    {{ $caption }}
@endif

{{ $component->getContainer()?->getRecord()?->id }}
```

The same possibility does not exist on rendered blade files, you have to find other ways of injecting the record ie. example with the app container.