### PR TITLE
fixing blocks panel dark bg class

### DIFF
--- a/resources/views/tiptap-editor.blade.php
+++ b/resources/views/tiptap-editor.blade.php
@@ -135,7 +135,7 @@
                                 }"
                                 class="hidden shrink-0 space-y-2 max-w-sm md:flex flex-col h-full"
                                 x-bind:class="{
-                                    'bg-gray-50 dark:bg-gray-950/20': ! isCollapsed,
+                                    'bg-gray-50 dark:bg-gray-900': ! isCollapsed,
                                     'h-full': ! isCollapsed && fullScreenMode,
                                     'px-2': ! fullScreenMode,
                                     'px-3': fullScreenMode


### PR DESCRIPTION
**In the dark version, the blocks panel looks like this:**

![image](https://github.com/awcodes/filament-tiptap-editor/assets/44981513/cda003ae-13f5-4e93-8943-fe1774fab38a)

**After the fix it will match the main color of the content:**

![image](https://github.com/awcodes/filament-tiptap-editor/assets/44981513/b7bf1951-3926-4dcc-a107-f00ee4e1bc8e)

