### PR TITLE
Fix: make modal work with Curator

### DIFF
--- a/resources/views/tiptap-editor.blade.php
+++ b/resources/views/tiptap-editor.blade.php
@@ -59,7 +59,7 @@
                     x-on:update-block.window="updateBlock($event)"
                     x-on:open-block-settings.window="openBlockSettings($event)"
                     x-on:delete-block.window="deleteBlock()"
-                    x-on:close-modal.window="destroyEditor($event)"
+{{--                    x-on:close-modal.window="destroyEditor($event)"--}}
                     x-trap.noscroll="fullScreenMode"
                 >
                     @if (! $isDisabled && ! $isToolbarMenusDisabled() && $tools)


### PR DESCRIPTION
This PR makes Curator work with editors in modals, but introduces a bug with clearing the editor instance when canceling the originating modal.