### PR TITLE
Fix: Make default direction LTR of pre.hljs tag

### DIFF
--- a/resources/css/plugin.css
+++ b/resources/css/plugin.css
@@ -406,8 +406,11 @@
         padding-inline: 0.25rem;
     }
 
-    pre.hljs code {
-        background-color: transparent;
+     pre.hljs {
+        direction: ltr;
+        code {
+            background-color: transparent;
+        }
     }
 
     .filament-tiptap-grid,


### PR DESCRIPTION
There is no code for right-to-left (RTL) direction in this section, so I am setting the default style of this tag to left-to-right (LTR). In the rare case (approximately 1%) where a developer needs to change the direction, they can do so manually. However, in 99% of cases, even in RTL layouts, the direction should remain LTR, which is the standard for most of all projects.