### PR TITLE
add edit_media_action config & saveUploadedFileUsing

### DIFF
--- a/config/filament-tiptap-editor.php
+++ b/config/filament-tiptap-editor.php
@@ -35,6 +35,7 @@ return [
     */
     'media_action' => FilamentTiptapEditor\Actions\MediaAction::class,
     //    'media_action' => Awcodes\Curator\Actions\MediaAction::class,
+    'edit_media_action' => FilamentTiptapEditor\Actions\EditMediaAction::class,
     'link_action' => FilamentTiptapEditor\Actions\LinkAction::class,
 
     /*

--- a/src/Actions/EditMediaAction.php
+++ b/src/Actions/EditMediaAction.php
@@ -96,7 +96,7 @@ class EditMediaAction extends Action
                                 $set('height', $dimensions[1]);
                             }
                         })
-                        ->saveUploadedFileUsing(function (BaseFileUpload $component, TemporaryUploadedFile $file, callable $set) {
+                        ->saveUploadedFileUsing($component->getSaveUploadedFileUsing() ?: function (BaseFileUpload $component, TemporaryUploadedFile $file, callable $set) {
                             $filename = $component->shouldPreserveFilenames() ? pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME) : Str::uuid();
                             $storeMethod = $component->getVisibility() === 'public' ? 'storePubliclyAs' : 'storeAs';
                             $extension = $file->getClientOriginalExtension();

--- a/src/Actions/MediaAction.php
+++ b/src/Actions/MediaAction.php
@@ -84,7 +84,7 @@ class MediaAction extends Action
                                 $set('height', $dimensions[1]);
                             }
                         })
-                        ->saveUploadedFileUsing(function (BaseFileUpload $component, TemporaryUploadedFile $file, callable $set) {
+                        ->saveUploadedFileUsing($component->getSaveUploadedFileUsing() ?: function (BaseFileUpload $component, TemporaryUploadedFile $file, callable $set) {
                             $filename = $component->shouldPreserveFilenames() ? pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME) : Str::uuid();
                             $storeMethod = $component->getVisibility() === 'public' ? 'storePubliclyAs' : 'storeAs';
                             $extension = $file->getClientOriginalExtension();

--- a/src/Concerns/HasCustomActions.php
+++ b/src/Concerns/HasCustomActions.php
@@ -11,6 +11,8 @@ trait HasCustomActions
 
     public ?string $mediaAction = null;
 
+    public ?string $editMediaAction = null;
+
     public function linkAction(string | Closure $action): static
     {
         $this->linkAction = $action;
@@ -35,6 +37,20 @@ trait HasCustomActions
     public function getMediaAction(): Action
     {
         $action = $this->evaluate($this->mediaAction) ?? config('filament-tiptap-editor.media_action');
+
+        return $action::make();
+    }
+
+    public function editMediaAction(string | Closure $action): static
+    {
+        $this->editMediaAction = $action;
+
+        return $this;
+    }
+
+    public function getEditMediaAction(): Action
+    {
+        $action = $this->evaluate($this->editMediaAction) ?? config('filament-tiptap-editor.edit_media_action');
 
         return $action::make();
     }

--- a/src/Concerns/InteractsWithMedia.php
+++ b/src/Concerns/InteractsWithMedia.php
@@ -33,6 +33,8 @@ trait InteractsWithMedia
 
     protected string | Closure | null $visibility = null;
 
+    protected ?Closure $saveUploadedFileUsing = null;
+
     public function acceptedFileTypes(array $acceptedFileTypes): static
     {
         $this->acceptedFileTypes = $acceptedFileTypes;
@@ -120,6 +122,13 @@ trait InteractsWithMedia
         return $this;
     }
 
+    public function saveUploadedFileUsing(?Closure $callback): static
+    {
+        $this->saveUploadedFileUsing = $callback;
+
+        return $this;
+    }
+
     public function getAcceptedFileTypes(): array
     {
         return $this->acceptedFileTypes ?? config('filament-tiptap-editor.accepted_file_types');
@@ -176,6 +185,11 @@ trait InteractsWithMedia
     public function getVisibility(): string
     {
         return $this->visibility ? $this->evaluate($this->visibility) : config('filament-tiptap-editor.visibility');
+    }
+
+    public function getSaveUploadedFileUsing(): ?Closure
+    {
+        return $this->saveUploadedFileUsing;
     }
 
     public function shouldPreserveFileNames(): bool

--- a/src/TiptapEditor.php
+++ b/src/TiptapEditor.php
@@ -8,7 +8,6 @@ use Filament\Forms\Components\Concerns\HasExtraInputAttributes;
 use Filament\Forms\Components\Concerns\HasPlaceholder;
 use Filament\Forms\Components\Field;
 use Filament\Support\Concerns\HasExtraAlpineAttributes;
-use FilamentTiptapEditor\Actions\EditMediaAction;
 use FilamentTiptapEditor\Actions\GridBuilderAction;
 use FilamentTiptapEditor\Actions\OEmbedAction;
 use FilamentTiptapEditor\Actions\SourceAction;
@@ -174,7 +173,7 @@ class TiptapEditor extends Field
             fn (): Action => $this->getMediaAction(),
             fn (): Action => $this->getInsertBlockAction(),
             fn (): Action => $this->getUpdateBlockAction(),
-            fn (): Action => EditMediaAction::make(),
+            fn (): Action => $this->getEditMediaAction(),
         ]);
     }
 


### PR DESCRIPTION
In the Media action configuration file, while customization was possible for other actions, the 'edit media' action was not customizable. To address this, the `edit_media_action` configuration has been implemented. Additionally, to enable custom upload logic, the `saveUploadedFileUsing` method has been added.