### PR TITLE
Update README.md: maxFileSize is Deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ TiptapEditor::make('content')
     ->disk('string') // optional, defaults to config setting
     ->directory('string or Closure returning a string') // optional, defaults to config setting
     ->acceptedFileTypes(['array of file types']) // optional, defaults to config setting
-    ->maxFileSize('integer in KB') // optional, defaults to config setting
+    ->maxSize('integer in KB') // optional, defaults to config setting
     ->output(TiptapOutput::Html) // optional, change the format for saved data, default is html
     ->maxContentWidth('5xl')
     ->required();


### PR DESCRIPTION
maxFileSize is Deprecated: Use `maxSize()` instead