### PR TITLE
Add more recognized image file types and compare file extension case insensitively

### DIFF
--- a/resources/js/plugin.js
+++ b/resources/js/plugin.js
@@ -474,9 +474,9 @@ export default function tiptap({
                 const imageTypes = ['jpg', 'jpeg', 'svg', 'png', 'webp', 'gif', 'avif', 'jxl', 'heic'];
 
                 const regex = /.*\.([a-zA-Z]*)\??/;
-                const match = regex.exec(src);
+                const match = regex.exec(src.toLowerCase());
 
-                if (match !== null && imageTypes.includes(match[1].toLowerCase())) {
+                if (match !== null && imageTypes.includes(match[1])) {
                     editor
                         .chain()
                         .focus()

--- a/resources/js/plugin.js
+++ b/resources/js/plugin.js
@@ -471,12 +471,12 @@ export default function tiptap({
 
             if (media) {
                 const src = media?.url || media?.src;
-                const imageTypes = ['jpg', 'jpeg', 'svg', 'png', 'webp', 'gif'];
+                const imageTypes = ['jpg', 'jpeg', 'svg', 'png', 'webp', 'gif', 'avif', 'jxl', 'heic'];
 
                 const regex = /.*\.([a-zA-Z]*)\??/;
                 const match = regex.exec(src);
 
-                if (match !== null && imageTypes.includes(match[1])) {
+                if (match !== null && imageTypes.includes(match[1].toLowerCase())) {
                     editor
                         .chain()
                         .focus()


### PR DESCRIPTION
Comparing file extension case sensitively fails to detect images when they have a capital file extension (such as JPEG). This fixes that issue.

This tries to fix issue #451 .