### PR TITLE
New Contents Table for TipTap Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ If you are using the `heading` tool in your editor you can also generate a table
 {!! tiptap_converter()->asToc($post->content, maxDepth: 3) !!}
 ```
 
+Alternatively, you can use & extend the `table-of-contents` blade component to generate the table of contents.
+
+```blade
+<!-- This will generate the TOC as a nested array, and use it as a parameter in the contents table -->
+<x-filament-tiptap-editor::table-of-contents :headings="tiptap_converter()->asTOC($page->body, array: true)" />
+```
+
 ## Config
 
 The plugin will work without publishing the config, but should you need to change any of the default settings you can publish the config file with the following Artisan command:

--- a/resources/views/components/table-of-contents.blade.php
+++ b/resources/views/components/table-of-contents.blade.php
@@ -1,0 +1,17 @@
+<ul>
+    @foreach ($headings as $heading)
+
+        <li>
+
+            <a href="#{{ $heading['id'] }}">{{ $heading['text'] }}</a>
+
+            @if (array_key_exists('subs', $heading))
+                <ul>
+                    <x-contents-table :headings="$heading['subs']" />
+                </ul>
+            @endif
+
+        </li>
+
+    @endforeach
+</ul>

--- a/resources/views/components/table-of-contents.blade.php
+++ b/resources/views/components/table-of-contents.blade.php
@@ -7,7 +7,7 @@
 
             @if (array_key_exists('subs', $heading))
                 <ul>
-                    <x-contents-table :headings="$heading['subs']" />
+                    <x-filament-tiptap-editor::table-of-contents :headings="$heading['subs']" />
                 </ul>
             @endif
 

--- a/resources/views/components/table-of-contents.blade.php
+++ b/resources/views/components/table-of-contents.blade.php
@@ -1,9 +1,13 @@
-<ul>
+@props([
+    'headings' => [],
+    'depth' => 0,
+])
+<ul class="filament-tiptap-contents-list" data-list-depth="{{$depth}}">
     @foreach ($headings as $heading)
-        <li>
-            <a href="#{{ $heading['id'] }}">{{ $heading['text'] }}</a>
+        <li class="filament-tiptap-contents-item">
+            <a class="filament-tiptap-contents-item" href="#{{ $heading['id'] }}">{{ $heading['text'] }}</a>
             @if (array_key_exists('subs', $heading))
-                <x-filament-tiptap-editor::table-of-contents :headings="$heading['subs']" />
+                <x-filament-tiptap-editor::table-of-contents :headings="$heading['subs']" :depth="$heading['depth']" />
             @endif
         </li>
     @endforeach

--- a/resources/views/components/table-of-contents.blade.php
+++ b/resources/views/components/table-of-contents.blade.php
@@ -1,17 +1,10 @@
 <ul>
     @foreach ($headings as $heading)
-
         <li>
-
             <a href="#{{ $heading['id'] }}">{{ $heading['text'] }}</a>
-
             @if (array_key_exists('subs', $heading))
-                <ul>
-                    <x-filament-tiptap-editor::table-of-contents :headings="$heading['subs']" />
-                </ul>
+                <x-filament-tiptap-editor::table-of-contents :headings="$heading['subs']" />
             @endif
-
         </li>
-
     @endforeach
 </ul>

--- a/resources/views/components/table-of-contents.blade.php
+++ b/resources/views/components/table-of-contents.blade.php
@@ -5,7 +5,7 @@
 <ul class="filament-tiptap-contents-list" data-list-depth="{{$depth}}">
     @foreach ($headings as $heading)
         <li class="filament-tiptap-contents-item">
-            <a class="filament-tiptap-contents-item" href="#{{ $heading['id'] }}">{{ $heading['text'] }}</a>
+            <a class="filament-tiptap-contents-url" href="#{{ $heading['id'] }}">{{ $heading['text'] }}</a>
             @if (array_key_exists('subs', $heading))
                 <x-filament-tiptap-editor::table-of-contents :headings="$heading['subs']" :depth="$heading['depth']" />
             @endif

--- a/src/TiptapConverter.php
+++ b/src/TiptapConverter.php
@@ -254,17 +254,14 @@ class TiptapConverter
             $heading = [
                 'id' => $value['id'],
                 'text' => $value['text'],
+                'depth' => $currentLevel,
             ];
 
-            // recursive if next heading is higher level
             if ($nextLevel > $currentLevel) {
                 $heading['subs'] = $this->generateTOCArray($headings, $currentLevel);
             }
 
-            // only add if higher than parent level
-            if ($currentLevel > $parentLevel) {
-                $result[] = $heading;
-            }
+            $result[] = $heading;
 
         }
 

--- a/src/TiptapConverter.php
+++ b/src/TiptapConverter.php
@@ -141,7 +141,7 @@ class TiptapConverter
         return $editor->getText();
     }
 
-    public function asTOC(string | array $content, int $maxDepth = 3): string
+    public function asTOC(string | array $content, int $maxDepth = 3, bool $array = false): string | array
     {
         if (is_string($content)) {
             $content = $this->asJSON($content, decoded: true);
@@ -149,7 +149,9 @@ class TiptapConverter
 
         $headings = $this->parseTocHeadings($content['content'], $maxDepth);
 
-        return $this->generateNestedTOC($headings, $headings[0]['level']);
+        return $array ?
+            $this->generateTOCArray($headings) :
+            $this->generateNestedTOC($headings, $headings[0]['level']);
     }
 
     public function parseHeadings(Editor $editor, int $maxDepth = 3): Editor
@@ -233,6 +235,41 @@ class TiptapConverter
         });
 
         return $editor;
+    }
+
+    public function generateTOCArray(&$headings, $parentLevel = 0): array {
+
+        $result = [];
+
+        foreach ($headings as $key => &$value) {
+            $currentLevel = $value['level'];
+            $nextLevel = $headings[$key + 1]['level'] ?? 0;
+
+            if ($parentLevel >= $currentLevel) {
+                break;
+            }
+
+            unset($headings[$key]);
+
+            $heading = [
+                'id' => $value['id'],
+                'text' => $value['text'],
+            ];
+
+            // recursive if next heading is higher level
+            if ($nextLevel > $currentLevel) {
+                $heading['subs'] = $this->generateTOCArray($headings, $currentLevel);
+            }
+
+            // only add if higher than parent level
+            if ($currentLevel > $parentLevel) {
+                $result[] = $heading;
+            }
+
+        }
+
+        return $result;
+
     }
 
     public function generateNestedTOC(array $headings, int $parentLevel = 0): string

--- a/src/TiptapConverter.php
+++ b/src/TiptapConverter.php
@@ -237,7 +237,7 @@ class TiptapConverter
         return $editor;
     }
 
-    public function generateTOCArray(&$headings, $parentLevel = 0): array {
+    public function generateTOCArray(array &$headings, int $parentLevel = 0): array {
 
         $result = [];
 


### PR DESCRIPTION
I was trying to use the Contents table built into the TipTap tool, but found it somewhat lacking.

The provided component `table-of-contents` cannot be properly used for a few reasons:

- It does not exist within the components folder so cannot be called within blade
- Calling within PHP throws errors due to improper array index checks
- Fixing the index calls will generate the TOC, but the resulting HTML is malformed.

The documentation also mentions the `asTOC` function, which works in a basic fashion, but also has 2 significant flaws.

1. The resulting HTML cannot be customised or themed.
2. The resulting HTML is also malformed, missing closing tags.

This PR fixes both of these issues by doing the following:

1. Provide a new function to generate the TOC as a nested array
2. Extend the existing `asTOC` function to output said array if specified 
3. Create a new `table-of-contents` component that can be called within Blade & published for modification
4. Allow the new component to use the array generated to display a table of contents

The original code for generating TOCs and the old `table-of-contents` component in the root has been preserved, so that backwards compatibility can be maintained.