### PR TITLE
Grid Builder Action is now customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ TiptapEditor::make('content')
 
 ## Overrides
 
-The Link and Media modals are built using Filament Form Component Actions. This means it is easy enough to swap them out with your own implementations.
+The Link, Media and Grid Builder modals are built using Filament Form Component Actions. This means it is easy enough to swap them out with your own implementations.
 
 ### Link Modal
 
@@ -226,6 +226,12 @@ See `vendor/awcodes/filament-tiptap-editor/src/Actions/LinkAction.php` for imple
 You may override the default Media modal with your own Action and assign to the `media_action` key in the config file. Make sure the default name for your action is `filament_tiptap_media`.
 
 See `vendor/awcodes/filament-tiptap-editor/src/Actions/MediaAction.php` for implementation.
+
+### Grid Builder Modal
+
+You may override the default Grid Builder modal with your own Action and assign to the `grid_builder_action` key in the config file. Make sure the default name for your action is `filament_tiptap_grid`.
+
+See `vendor/awcodes/filament-tiptap-editor/src/Actions/GridBuilderAction.php` for implementation.
 
 ### Initial height of editor field
 

--- a/config/filament-tiptap-editor.php
+++ b/config/filament-tiptap-editor.php
@@ -37,6 +37,7 @@ return [
     //    'media_action' => Awcodes\Curator\Actions\MediaAction::class,
     'edit_media_action' => FilamentTiptapEditor\Actions\EditMediaAction::class,
     'link_action' => FilamentTiptapEditor\Actions\LinkAction::class,
+    'grid_builder_action' => FilamentTiptapEditor\Actions\GridBuilderAction::class,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Concerns/HasCustomActions.php
+++ b/src/Concerns/HasCustomActions.php
@@ -13,6 +13,8 @@ trait HasCustomActions
 
     public ?string $editMediaAction = null;
 
+    public ?string $gridBuilderAction = null;
+
     public function linkAction(string | Closure $action): static
     {
         $this->linkAction = $action;
@@ -52,6 +54,19 @@ trait HasCustomActions
     {
         $action = $this->evaluate($this->editMediaAction) ?? config('filament-tiptap-editor.edit_media_action');
 
+        return $action::make();
+    }
+
+    public function gridBuilderAction(string | Closure $action): static
+    {
+        $this->gridBuilderAction = $action;
+
+        return $this;
+    }
+
+    public function getGridBuilderAction(): Action
+    {
+        $action = $this->evaluate($this->gridBuilderAction) ?? config('filament-tiptap-editor.grid_builder_action');
         return $action::make();
     }
 }

--- a/src/TiptapEditor.php
+++ b/src/TiptapEditor.php
@@ -168,7 +168,7 @@ class TiptapEditor extends Field
         $this->registerActions([
             SourceAction::make(),
             OEmbedAction::make(),
-            GridBuilderAction::make(),
+            fn (): Action => $this->getGridBuilderAction(),
             fn (): Action => $this->getLinkAction(),
             fn (): Action => $this->getMediaAction(),
             fn (): Action => $this->getInsertBlockAction(),


### PR DESCRIPTION
I was looking for a way to customize the modal of the Grid Builder action yet only found the LinkAction and MediaAction to be customizable. So I tried to remedy that.

