### PR TITLE
Adding image editor functions to tiptap editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ Tools can also be added on a per-instance basis by using the `->tools()` modifie
     'image_crop_aspect_ratio' => null,
     'image_resize_target_width' => null,
     'image_resize_target_height' => null,
+    'image_editor_empty_fill_color' => null,
+    'image_editor_mode' => 1,
+    'image_editor_viewport_height' => null,
+    'image_editor_viewport_width' => null,
+    'image_editor_aspect_ratios' => [],
 ]
 ```
 

--- a/config/filament-tiptap-editor.php
+++ b/config/filament-tiptap-editor.php
@@ -73,6 +73,11 @@ return [
     'image_crop_aspect_ratio' => null,
     'image_resize_target_width' => null,
     'image_resize_target_height' => null,
+    'image_editor_empty_fill_color' => null,
+    'image_editor_mode' => 1,
+    'image_editor_viewport_height' => null,
+    'image_editor_viewport_width' => null,
+    'image_editor_aspect_ratios' => [],
     'use_relative_paths' => true,
 
     /*

--- a/src/Actions/EditMediaAction.php
+++ b/src/Actions/EditMediaAction.php
@@ -82,6 +82,13 @@ class EditMediaAction extends Action
                         ->imageCropAspectRatio($component->getImageCropAspectRatio())
                         ->imageResizeTargetWidth($component->getImageResizeTargetWidth())
                         ->imageResizeTargetHeight($component->getImageResizeTargetHeight())
+                        ->circleCropper($component->hasCircleCropper())
+                        ->imageEditor($component->hasImageEditor())
+                        ->imageEditorEmptyFillColor($component->getImageEditorEmptyFillColor())
+                        ->imageEditorMode($component->getImageEditorMode())
+                        ->imageEditorViewportHeight($component->getImageEditorViewportHeight())
+                        ->imageEditorViewportWidth($component->getImageEditorViewportWidth())
+                        ->imageEditorAspectRatios($component->getImageEditorAspectRatios())
                         ->required()
                         ->live()
                         ->afterStateUpdated(function (TemporaryUploadedFile $state, callable $set) {

--- a/src/Actions/MediaAction.php
+++ b/src/Actions/MediaAction.php
@@ -70,6 +70,13 @@ class MediaAction extends Action
                         ->imageCropAspectRatio($component->getImageCropAspectRatio())
                         ->imageResizeTargetWidth($component->getImageResizeTargetWidth())
                         ->imageResizeTargetHeight($component->getImageResizeTargetHeight())
+                        ->circleCropper($component->hasCircleCropper())
+                        ->imageEditor($component->hasImageEditor())
+                        ->imageEditorEmptyFillColor($component->getImageEditorEmptyFillColor())
+                        ->imageEditorMode($component->getImageEditorMode())
+                        ->imageEditorViewportHeight($component->getImageEditorViewportHeight())
+                        ->imageEditorViewportWidth($component->getImageEditorViewportWidth())
+                        ->imageEditorAspectRatios($component->getImageEditorAspectRatios())
                         ->required()
                         ->live()
                         ->afterStateUpdated(function (TemporaryUploadedFile $state, callable $set) {

--- a/src/Concerns/InteractsWithMedia.php
+++ b/src/Concerns/InteractsWithMedia.php
@@ -33,6 +33,20 @@ trait InteractsWithMedia
 
     protected string | Closure | null $visibility = null;
 
+    protected bool | Closure $hasCircleCropper = false;
+
+    protected bool | Closure $hasImageEditor = false;
+
+    protected string | Closure | null $imageEditorEmptyFillColor = null;
+
+    protected int $imageEditorMode = 1;
+
+    protected int | Closure | null $imageEditorViewportHeight = null;
+
+    protected int | Closure | null $imageEditorViewportWidth = null;
+
+    protected array | Closure $imageEditorAspectRatios = [];
+
     protected ?Closure $saveUploadedFileUsing = null;
 
     public function acceptedFileTypes(array $acceptedFileTypes): static
@@ -122,6 +136,64 @@ trait InteractsWithMedia
         return $this;
     }
 
+    public function circleCropper(bool | Closure $condition = true): static
+    {
+        $this->hasCircleCropper = $condition;
+
+        return $this;
+    }
+
+    public function imageEditor(bool | Closure $condition = true): static
+    {
+        $this->hasImageEditor = $condition;
+
+        return $this;
+    }
+
+    public function imageEditorEmptyFillColor(string | Closure | null $color): static
+    {
+        $this->imageEditorEmptyFillColor = $color;
+
+        return $this;
+    }
+
+    /**
+     * @param int $mode 1,2 or 3
+     * - 1: restrict the crop box not to exceed the size of the canvas (default).
+     * - 2: restrict the minimum canvas size to fit within the container. If the proportions of the canvas and the container differ, the minimum canvas will be surrounded by extra space in one of the dimensions.
+     * - 3: restrict the minimum canvas size to fill fit the container. If the proportions of the canvas and the container are different, the container will not be able to fit the whole canvas in one of the dimensions.
+     */
+    public function imageEditorMode(int $mode): static
+    {
+        $this->imageEditorMode = $mode;
+
+        return $this;
+    }
+
+    public function imageEditorViewportHeight(int $height): static
+    {
+        $this->imageEditorViewportHeight = $height;
+
+        return $this;
+    }
+
+    public function imageEditorViewportWidth(int $width): static
+    {
+        $this->imageEditorViewportWidth = $width;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<?string> | Closure  $ratios
+     */
+    public function imageEditorAspectRatios(array | Closure $ratios): static
+    {
+        $this->imageEditorAspectRatios = $ratios;
+
+        return $this;
+    }
+
     public function saveUploadedFileUsing(?Closure $callback): static
     {
         $this->saveUploadedFileUsing = $callback;
@@ -185,6 +257,41 @@ trait InteractsWithMedia
     public function getVisibility(): string
     {
         return $this->visibility ? $this->evaluate($this->visibility) : config('filament-tiptap-editor.visibility');
+    }
+
+    public function hasCircleCropper(): bool
+    {
+        return (bool) $this->evaluate($this->hasCircleCropper);
+    }
+
+    public function hasImageEditor(): bool
+    {
+        return (bool) $this->evaluate($this->hasImageEditor);
+    }
+
+    public function getImageEditorEmptyFillColor(): ?string
+    {
+        return $this->imageEditorEmptyFillColor ? $this->evaluate($this->imageEditorEmptyFillColor) : config('filament-tiptap-editor.image_editor_empty_fill_color');
+    }
+
+    public function getImageEditorMode(): int
+    {
+        return in_array($this->imageEditorMode, [1,2,3]) ? $this->imageEditorMode : config('filament-tiptap-editor.image_editor_mode');
+    }
+
+    public function getImageEditorViewportHeight(): ?int
+    {
+        return $this->imageEditorViewportHeight ? $this->evaluate($this->imageEditorViewportHeight) : config('filament-tiptap-editor.image_editor_viewport_height');
+    }
+
+    public function getImageEditorViewportWidth(): ?int
+    {
+        return $this->imageEditorViewportWidth ? $this->evaluate($this->imageEditorViewportWidth) : config('filament-tiptap-editor.image_editor_viewport_width');
+    }
+
+    public function getImageEditorAspectRatios(): array
+    {
+        return $this->imageEditorAspectRatios ?? config('filament-tiptap-editor.image_editor_aspect_ratios');
     }
 
     public function getSaveUploadedFileUsing(): ?Closure


### PR DESCRIPTION
# Title

Adding filament image editor functions to MediaAction and EditMediaAction.

## Functions that were added

- `circleCropper`.
- `imageEditor`: The most essential.
- `imageEditorEmptyFillColor`.
- `imageEditorMode`.
- `imageEditorViewportHeight`.
- `imageEditorViewportWidth`.
- `imageEditorAspectRatios`.

## Why?

While working on various projects using Laravel Filament, I noticed that when implementing the Tiptap Editor, particularly for projects with a blogging feature, users often want the ability to edit images after they have uploaded them. This functionality is similar to what is offered by Filament’s [FileUpload component](https://filamentphp.com/docs/3.x/forms/fields/file-upload). So, I decided to incorporate the essential features that would facilitate this process.

## What did I do/edit?

In addition to adding these functions, I updated the README.md file to reflect the new properties in the config file.