### PR TITLE
feat: implemented the possibility of overwriting the `OEmbedAction` file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,12 @@ You may override the default Grid Builder modal with your own Action and assign 
 
 See `vendor/awcodes/filament-tiptap-editor/src/Actions/GridBuilderAction.php` for implementation.
 
+### OEmbed Modal
+
+You may override the default OEmbed modal with your own Action and assign to the `oembed_action` key in the config file. Make sure the default name for your action is `filament_tiptap_grid`.
+
+See `vendor/awcodes/filament-tiptap-editor/src/Actions/OEmbedAction.php` for implementation.
+
 ### Initial height of editor field
 
 You can add extra input attributes to the field with the `extraInputAttributes()` method. This allows you to do things like set the initial height of the editor.

--- a/config/filament-tiptap-editor.php
+++ b/config/filament-tiptap-editor.php
@@ -38,6 +38,7 @@ return [
     'edit_media_action' => FilamentTiptapEditor\Actions\EditMediaAction::class,
     'link_action' => FilamentTiptapEditor\Actions\LinkAction::class,
     'grid_builder_action' => FilamentTiptapEditor\Actions\GridBuilderAction::class,
+    'oembed_action' => FilamentTiptapEditor\Actions\OEmbedAction::class,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Concerns/HasCustomActions.php
+++ b/src/Concerns/HasCustomActions.php
@@ -15,6 +15,8 @@ trait HasCustomActions
 
     public ?string $gridBuilderAction = null;
 
+    public ?string $oembedAction = null;
+
     public function linkAction(string | Closure $action): static
     {
         $this->linkAction = $action;
@@ -25,6 +27,13 @@ trait HasCustomActions
     public function mediaAction(string | Closure $action): static
     {
         $this->mediaAction = $action;
+
+        return $this;
+    }
+
+    public function oembedAction(string | Closure $action): static
+    {
+        $this->oembedAction = $action;
 
         return $this;
     }
@@ -67,6 +76,13 @@ trait HasCustomActions
     public function getGridBuilderAction(): Action
     {
         $action = $this->evaluate($this->gridBuilderAction) ?? config('filament-tiptap-editor.grid_builder_action');
+
+        return $action::make();
+    }
+
+    public function getOEmbedAction(): Action
+    {
+        $action = $this->evaluate($this->oembedAction) ?? config('filament-tiptap-editor.oembed_action');
 
         return $action::make();
     }

--- a/src/TiptapEditor.php
+++ b/src/TiptapEditor.php
@@ -8,7 +8,6 @@ use Filament\Forms\Components\Concerns\HasExtraInputAttributes;
 use Filament\Forms\Components\Concerns\HasPlaceholder;
 use Filament\Forms\Components\Field;
 use Filament\Support\Concerns\HasExtraAlpineAttributes;
-use FilamentTiptapEditor\Actions\OEmbedAction;
 use FilamentTiptapEditor\Actions\SourceAction;
 use FilamentTiptapEditor\Concerns\CanStoreOutput;
 use FilamentTiptapEditor\Concerns\HasCustomActions;
@@ -166,7 +165,7 @@ class TiptapEditor extends Field
 
         $this->registerActions([
             SourceAction::make(),
-            OEmbedAction::make(),
+            fn (): Action => $this->getOEmbedAction(),
             fn (): Action => $this->getGridBuilderAction(),
             fn (): Action => $this->getLinkAction(),
             fn (): Action => $this->getMediaAction(),


### PR DESCRIPTION
### Description
The OEmbedAction file is responsible for structuring the video addition modal. With this feature we offer the possibility to customize the structure of the video modal.

### Code changes
- Added new config file variable: `oembed_action`.
- Implemented configuration logic in the `HasCustomActions` trait.
- Call to the getter that will decide which class is responsible for managing the OEmbedAction structure in TiptapEditor file. 
- Explaining in the README.md.


This PR would resolve the conflict outlined in discussion #502