### PR TITLE
Allow nullable buttons for tools

### DIFF
--- a/resources/views/tiptap-editor.blade.php
+++ b/resources/views/tiptap-editor.blade.php
@@ -78,7 +78,9 @@
                                             @elseif ($tool === '-')
                                                 <div class="border-t border-gray-950/10 dark:border-white/20 w-full"></div>
                                             @elseif (is_array($tool))
+                                                @if(array_key_exists('button', $tool) && !is_null($tool['button']))
                                                 <x-dynamic-component component="{{ $tool['button'] }}" :state-path="$statePath" />
+                                                @endif
                                             @elseif ($tool === 'blocks')
                                                 @if ($blocks && $shouldSupportBlocks)
                                                     <x-filament-tiptap-editor::tools.blocks :blocks="$blocks" :state-path="$statePath" />


### PR DESCRIPTION
I find that you sometimes do not want to display a button when creating a custom extension. For example, today I created a custom extension that adds a `title` block at the start, similarly how Confluence does it:

<img width="516" alt="afbeelding" src="https://github.com/user-attachments/assets/fd38f03f-e9d7-4d96-a70a-3ed3b0ffd75f">

In this case, I do not want my custom extension to have a button in the toolbar, since my custom functionality is all in the background. That is why I made the `button` attribute nullable in this PR.