### PR TITLE
Add PresetColors to ColorPicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,22 @@ TiptapEditor::make('content')
     ->extraInputAttributes(['style' => 'min-height: 12rem;']),
 ```
 
+## Colors preset
+
+By default, the ColorPicker shows a picker and a field to set hexadecimal color to selected text. Registering specific colors in config file, you can choose one of them directly in ColorPicker
+To do, simply set your custom colors in config file ```preset_colors``` key
+
+    
+```php
+'preset_colors' => [
+    'primary' => '#f59e0b',
+    'secondary' => '#14b8a6',
+    'red' => '#ef4444',
+    //..
+]
+```
+
+
 ## Bubble and Floating Menus
 
 By default, the editor uses Bubble and Floating menus to help with creating content inline, so you don't have to use the toolbar. If you'd prefer to not use the menus you can disable them on a per-instance basis or globally in the config file.

--- a/config/filament-tiptap-editor.php
+++ b/config/filament-tiptap-editor.php
@@ -98,4 +98,19 @@ return [
     'extensions_script' => null,
     'extensions_styles' => null,
     'extensions' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | PresetColors
+    |--------------------------------------------------------------------------
+    |
+    | Possibility to define presets colors in ColorPicker.
+    | Only hexadecimal value
+    'preset_colors' => [
+        'primary' => '#f59e0b',
+        //..
+    ]
+    |
+    */
+    'preset_colors' => [],
 ];

--- a/resources/views/components/tools/color.blade.php
+++ b/resources/views/components/tools/color.blade.php
@@ -39,6 +39,20 @@
             <span class="sr-only">{{ trans('filament-tiptap-editor::editor.color.input_label') }}</span>
         </label>
 
+        @if(!empty(config('filament-tiptap-editor.preset_colors')))
+        <div class="mt-2 flex flex-wrap justify-start gap-2">
+            @foreach(config('filament-tiptap-editor.preset_colors') as $name => $value)
+                <span
+                    x-tooltip.raw="{{ $name }}"
+                    class="rounded-full w-5 h-5 cursor-pointer"
+                    style="background-color:{{ $value }};"
+                    x-on:click="setState('{{ $value }}'); editor().chain().focus().setColor(state).run(); $dispatch('close-panel')"
+                >
+            </span>
+            @endforeach
+        </div>
+        @endif
+
         <div class="w-full flex gap-2 mt-2">
             <x-filament::button
                 x-on:click="editor().chain().focus().setColor(state).run(); $dispatch('close-panel')"

--- a/resources/views/components/tools/color.blade.php
+++ b/resources/views/components/tools/color.blade.php
@@ -39,14 +39,15 @@
             <span class="sr-only">{{ trans('filament-tiptap-editor::editor.color.input_label') }}</span>
         </label>
 
-        @if(!empty(config('filament-tiptap-editor.preset_colors')))
+        @if(filled(config('filament-tiptap-editor.preset_colors')))
         <div class="mt-2 flex flex-wrap justify-start gap-2">
             @foreach(config('filament-tiptap-editor.preset_colors') as $name => $value)
                 <span
+                    wire:key="{{ $name }}"
                     x-tooltip.raw="{{ $name }}"
                     class="rounded-full w-5 h-5 cursor-pointer"
                     style="background-color:{{ $value }};"
-                    x-on:click="setState('{{ $value }}'); editor().chain().focus().setColor(state).run(); $dispatch('close-panel')"
+                    x-on:click="setState('{{ $value }}');"
                 >
             </span>
             @endforeach


### PR DESCRIPTION
## Description

Adding possibility to use presets colors in ColorPicker modal.

## Visual changes

### Before
![Capture d’écran 2024-12-18 à 15 46 57](https://github.com/user-attachments/assets/dd167dd6-c2f0-4120-8c5a-3496971d311d)

### After
![Capture d’écran 2024-12-18 à 15 47 35](https://github.com/user-attachments/assets/8e3b7813-4727-4a7a-9661-255c8840cd01)
