### PR TITLE
`img` attributes to facilitate the use of Responsive Images & Media Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The Media Modal can make use of 3 attributes not exposed by default:
 
 - `srcset` is used for selecting a series of responsive images to display for different browser viewports. [Docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset)
 - `sizes` goes alongside `srcset` to specify sizing rules for responsive images. [Docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/sizes)
-- `media` provides support for an arbitrary ID vlaue to better integrate with Media Libraries, so that data about which media was used can be preserved.
+- `media` provides support for an arbitrary ID value to better integrate with Media stored within a Database.
 
 See `vendor/awcodes/filament-tiptap-editor/src/Actions/MediaAction.php` for implementation.
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,12 @@ See `vendor/awcodes/filament-tiptap-editor/src/Actions/LinkAction.php` for imple
 
 You may override the default Media modal with your own Action and assign to the `media_action` key in the config file. Make sure the default name for your action is `filament_tiptap_media`.
 
+The Media Modal can make use of 3 attributes not exposed by default:
+
+- `srcset` is used for selecting a series of responsive images to display for different browser viewports. [Docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset)
+- `sizes` goes alongside `srcset` to specify sizing rules for responsive images. [Docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/sizes)
+- `media` provides support for an arbitrary ID vlaue to better integrate with Media Libraries, so that data about which media was used can be preserved.
+
 See `vendor/awcodes/filament-tiptap-editor/src/Actions/MediaAction.php` for implementation.
 
 ### Grid Builder Modal

--- a/resources/js/extensions/Image.js
+++ b/resources/js/extensions/Image.js
@@ -29,7 +29,22 @@ export const CustomImage = Image.extend({
             };
           }
         }
-      }
+      },
+      srcset: {
+        default: null,
+      },
+      sizes: {
+        default: null,
+      },
+      media: {
+        default: null,
+        parseHTML: element => element.getAttribute('data-media-id'),
+        renderHTML: (attributes) => {
+          if (attributes.media) {
+            return { "data-media-id": attributes.media };
+          }
+        },
+      },
     };
   },
 });

--- a/resources/js/extensions/Image.js
+++ b/resources/js/extensions/Image.js
@@ -39,9 +39,13 @@ export const CustomImage = Image.extend({
       media: {
         default: null,
         parseHTML: element => element.getAttribute('data-media-id'),
-        renderHTML: (attributes) => {
-          if (attributes.media) {
-            return { "data-media-id": attributes.media };
+        renderHTML: attributes => {
+          if (!attributes.media) {
+            return {}
+          }
+
+          return {
+            'data-media-id': attributes.media,
           }
         },
       },

--- a/resources/js/plugin.js
+++ b/resources/js/plugin.js
@@ -449,7 +449,7 @@ export default function tiptap({
                             height: media?.height,
                             lazy: media?.lazy,
                             srcset: media?.srcset,
-                            sizes: media?.srcset,
+                            sizes: media?.sizes,
                             media: media?.media,
                         })
                         .run();

--- a/resources/js/plugin.js
+++ b/resources/js/plugin.js
@@ -448,6 +448,9 @@ export default function tiptap({
                             width: media?.width,
                             height: media?.height,
                             lazy: media?.lazy,
+                            srcset: media?.srcset,
+                            sizes: media?.srcset,
+                            media: media?.media,
                         })
                         .run();
                 } else {

--- a/src/Extensions/Nodes/Image.php
+++ b/src/Extensions/Nodes/Image.php
@@ -43,15 +43,9 @@ class Image extends BaseImage
             ],
             'media' => [
                 'default' => null,
-                'parseHTML' => function ($DOMNode) {
-                    return $DOMNode->getAttribute('data-media-id');
-                },
-                'renderHTML' => function ($attributes) {
-                    return $attributes->media
-                        ? ['data-media-id' => $attributes->media]
-                        : null;
-                },
-            ]
+                'parseHTML' => fn ($DOMNode) => $DOMNode->getAttribute('data-media-id') ?: null,
+                'renderHTML' => fn ($attributes) => $attributes->media ? ['data-media-id' => $attributes->media] : null,
+            ],
         ];
     }
 }

--- a/src/Extensions/Nodes/Image.php
+++ b/src/Extensions/Nodes/Image.php
@@ -35,6 +35,23 @@ class Image extends BaseImage
                         : null;
                 },
             ],
+            'srcset' => [
+                'default' => null,
+            ],
+            'sizes' => [
+                'default' => null,
+            ],
+            'media' => [
+                'default' => null,
+                'parseHTML' => function ($DOMNode) {
+                    return $DOMNode->getAttribute('data-media-id');
+                },
+                'renderHTML' => function ($attributes) {
+                    return $attributes->media
+                        ? ['data-media-id' => $attributes->media]
+                        : null;
+                },
+            ]
         ];
     }
 }


### PR DESCRIPTION
For #249
Recreation of #489 

- src / size are for responsive image support a la Spatie Media Library
- data-media-id is for storing / parsing IDs used by a Media Library of any sort

The reason I recreated this was due to inactivity on the other PR, and to split the media item changes into a PR separate from adding a new iFrame node.

The iFrame node would still be beneficial, in my opinion, but I'll let @rubenlopezgea-at-coodex manage that.