### PR TITLE
Fixed README error for custom OEmbed modals

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ See `vendor/awcodes/filament-tiptap-editor/src/Actions/GridBuilderAction.php` fo
 
 ### OEmbed Modal
 
-You may override the default OEmbed modal with your own Action and assign to the `oembed_action` key in the config file. Make sure the default name for your action is `filament_tiptap_grid`.
+You may override the default OEmbed modal with your own Action and assign to the `oembed_action` key in the config file. Make sure the default name for your action is `filament_tiptap_oembed`.
 
 See `vendor/awcodes/filament-tiptap-editor/src/Actions/OEmbedAction.php` for implementation.
 


### PR DESCRIPTION
The readme states that you have to use the default name `filament_tiptap_grid` when you want to overwrite the OEmbed Modal. This is an error: you should use the `filament_tiptap_oembed` default name instead:

```php
class OEmbedAction extends Action
{
    public static function getDefaultName(): ?string
    {
        return 'filament_tiptap_oembed';
    }
    ...
 ```
 
 I updated the readme to fix this instruction.