### PR TITLE
fix: enable module loading for custom extensions

### DIFF
--- a/src/FilamentTiptapEditorServiceProvider.php
+++ b/src/FilamentTiptapEditorServiceProvider.php
@@ -38,7 +38,7 @@ class FilamentTiptapEditorServiceProvider extends PackageServiceProvider
         ];
 
         if (config('filament-tiptap-editor.extensions_script')) {
-            $assets[] = Js::make('tiptap-custom-extension-scripts', Vite::asset(config('filament-tiptap-editor.extensions_script')));
+            $assets[] = Js::make('tiptap-custom-extension-scripts', Vite::asset(config('filament-tiptap-editor.extensions_script')))->module();
         }
 
         if (config('filament-tiptap-editor.extensions_styles')) {


### PR DESCRIPTION
Currently, the package loads custom extension scripts as regular JavaScript files, which prevents the use of ES module syntax (`import` statements). This means even the example snippet in the docs will not work, nor will using extensions from packages like `@tiptap-pro`, be very straighforward to use

```js
import Hero from "./hero.js";
window.TiptapEditorExtensions = {
    hero: [Hero]
}
```
This code fails with `Uncaught SyntaxError: Cannot use import statement outside a module`.

This PR modifies the asset registration to load custom extension scripts as modules by using Filament's `module()` method, allowing one to  use ES module syntax in their extension scripts