### PR TITLE
Avoid error when generating TOC on page without titles

### DIFF
--- a/src/TiptapConverter.php
+++ b/src/TiptapConverter.php
@@ -168,6 +168,10 @@ class TiptapConverter
 
         $headings = $this->parseTocHeadings($content['content'], $maxDepth);
 
+        if(empty($headings)) {
+            return $array ? [] : '';
+        }
+
         return $array ?
             $this->generateTOCArray($headings) :
             $this->generateNestedTOC($headings, $headings[0]['level']);


### PR DESCRIPTION
Fixes error `ErrorException: Undefined array key 0 in /vendor/awcodes/filament-tiptap-editor/src/TiptapConverter.php:173`
As reported in https://github.com/awcodes/filament-tiptap-editor/issues/539