### PR TITLE
Fix: support for new media attribute as action mount argument

### DIFF
--- a/resources/views/components/tools/edit-media.blade.php
+++ b/resources/views/components/tools/edit-media.blade.php
@@ -23,6 +23,7 @@
                 width: media.width || '',
                 height: media.height || '',
                 lazy: media.lazy || false,
+                media: media.media || '',
             };
 
             {{ $action }}

--- a/resources/views/components/tools/media.blade.php
+++ b/resources/views/components/tools/media.blade.php
@@ -27,6 +27,7 @@
                 width: media.width || '',
                 height: media.height || '',
                 lazy: media.lazy || false,
+                media: media.media || '',
             };
 
             {{ $action }}


### PR DESCRIPTION
Hey Adam, all the best with your health. You're likely not really caring about this, but just putting it here until you feel like it again.

Currently, #524 added support for storing a random media `data-media-id` attribute to identify an image based on that ID instead of on e.g. the `title`. However, this property was not added as an argument to be available in the `mountUsing()`, because the Blade still had to be adapted.