### PR TITLE
Fix: Added check to allow for assoc arrays with string keys

### DIFF
--- a/src/TiptapEditor.php
+++ b/src/TiptapEditor.php
@@ -516,6 +516,10 @@ class TiptapEditor extends Field
 
     public function mergeTags(array | Closure $mergeTags): static
     {
+        if (null !== array_keys($mergeTags)) {
+            $mergeTags = array_values($mergeTags);
+        }
+        
         $this->mergeTags = $mergeTags;
 
         return $this;


### PR DESCRIPTION
I ran into an issue where entering an array that had strings has keys to the `->mergeTags()` method resulted in an error when attempting to add the merge tag to the editor content. 