### PR TITLE
Feature: Cleanup Removed Images

### DIFF
--- a/src/TiptapEditor.php
+++ b/src/TiptapEditor.php
@@ -559,6 +559,8 @@ class TiptapEditor extends Field
     public function cleanUpDeletedImages(bool $condition = true): static
     {
         $this->cleanUpImagesOnUpdated = $condition;
+
+        return $this;
     }
 
     private function deleteRemovedImages(array $old, array $state, TiptapEditor $component): void


### PR DESCRIPTION
##Feature: Optionally Cleanup Removed Images

This PR introduces automatic cleanup of images that are removed from the Tiptap editor content. When an image is deleted from the editor, the corresponding file is also removed from the storage disk. This ensures that unused images do not accumulate, saving disk space and maintaining a clean storage environment.

- This option is off by default ( non-breaking)
- It can be enabled by: `TiptapEditor::make('foo')->cleanUpDeletedImages()`