### PR TITLE
fix: include srcset adnd sizes as media mount arguments

### DIFF
--- a/resources/views/components/tools/edit-media.blade.php
+++ b/resources/views/components/tools/edit-media.blade.php
@@ -24,6 +24,8 @@
                 height: media.height || '',
                 lazy: media.lazy || false,
                 media: media.media || '',
+                srcset: media.srcset || '',
+                sizes: media.sizes || '',
             };
 
             {{ $action }}

--- a/resources/views/components/tools/media.blade.php
+++ b/resources/views/components/tools/media.blade.php
@@ -28,6 +28,8 @@
                 height: media.height || '',
                 lazy: media.lazy || false,
                 media: media.media || '',
+                srcset: media.srcset || '',
+                sizes: media.sizes || '',
             };
 
             {{ $action }}


### PR DESCRIPTION
Fix for #524 as an extension of #547 

Forgot to include the mount arguments for the media modal for these on my last PR. Following Ralph's PR including this for the arbitrary media ID attribute, this adds the mount arguments for the `srcset` and `sizes` attributes.

