### PR TITLE
Default word-break CSS

### DIFF
--- a/resources/css/plugin.css
+++ b/resources/css/plugin.css
@@ -55,6 +55,7 @@
 
 .tiptap-prosemirror-wrapper {
     word-break: break-word;
+    overflow-wrap: break-word;
     &.prosemirror-w-sm { padding: 0 max(theme('padding.4'), calc((100% - theme('maxWidth.sm')) / 2)); }
     &.prosemirror-w-md { padding: 0 max(theme('padding.4'), calc((100% - theme('maxWidth.md')) / 2)); }
     &.prosemirror-w-lg { padding: 0 max(theme('padding.4'), calc((100% - theme('maxWidth.lg')) / 2)); }

--- a/resources/css/plugin.css
+++ b/resources/css/plugin.css
@@ -54,7 +54,7 @@
 }
 
 .tiptap-prosemirror-wrapper {
-    word-break: break-all;
+    word-break: break-word;
     &.prosemirror-w-sm { padding: 0 max(theme('padding.4'), calc((100% - theme('maxWidth.sm')) / 2)); }
     &.prosemirror-w-md { padding: 0 max(theme('padding.4'), calc((100% - theme('maxWidth.md')) / 2)); }
     &.prosemirror-w-lg { padding: 0 max(theme('padding.4'), calc((100% - theme('maxWidth.lg')) / 2)); }


### PR DESCRIPTION
Firstly thanks for a great plugin!

I noticed that the change in #567 for issue #566 , although fixing the problem of overflowing long words, caused every word to break onto a new line no matter the length (as shown below). This made for unusual reading inside the editor so I wanted to see if there was a way to accommodate all cases.

![Screenshot 2025-04-08 at 15 55 26](https://github.com/user-attachments/assets/3cb36f5a-ab92-47df-8f05-c4747b4e91a3)

My changes are:
- Changed the default `word-break` from `break-all` to `break-word`
- Added `overflow-wrap: break-word` to maximise browser compatibility

I have checked that this functionality does not affect the original issue, so extended length words (including underscores etc.) are still correctly split.

Very much open to ideas/suggestions for this, thanks!