### PR TITLE
Condition to skip foraech if $column is null

### DIFF
--- a/resources/views/components/grid-modal-preview.blade.php
+++ b/resources/views/components/grid-modal-preview.blade.php
@@ -20,11 +20,13 @@
                 <p>1</p>
             </div>
         @else
-            @foreach(range(1, $data['columns']) as $column)
-                <div class="bg-gray-300 dark:bg-gray-800 rounded-lg border border-dashed border-white dark:border-gray-600 p-0.5 text-center">
-                    <p>{{ $column }}</p>
-                </div>
-            @endforeach
+            @if(!empty($data['columns']) && $data['columns'] > 0)
+                @foreach(range(1, $data['columns']) as $column)
+                    <div class="bg-gray-300 dark:bg-gray-800 rounded-lg border border-dashed border-white dark:border-gray-600 p-0.5 text-center">
+                        <p>{{ $column }}</p>
+                    </div>
+                @endforeach
+            @endif
         @endif
     </div>
 </div>


### PR DESCRIPTION
Added condition for foreach to be executed only if $column exists and is greater than 0. Fixing issue #641 .